### PR TITLE
ニコ動のSSL化に対応

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -8,7 +8,7 @@
 		"128":"icon128.png"
 	},
 	"content_scripts":[{
-		"matches":["http://www.nicovideo.jp/my/top","http://www.nicovideo.jp/my/top/*","http://www.nicovideo.jp/user/*"],
+		"matches":["https://www.nicovideo.jp/my/top","https://www.nicovideo.jp/my/top/*","https://www.nicovideo.jp/user/*"],
 		"js":["contentScript.js"]
 	}]
 }


### PR DESCRIPTION
2018/10/11にようやく全面SSLになったのでURLを変更しただけです。
http://blog.nicovideo.jp/niconews/90007.html